### PR TITLE
Update block_extract README

### DIFF
--- a/POST/block_extract/README.md
+++ b/POST/block_extract/README.md
@@ -29,19 +29,6 @@ where VAR1 VAR2 ... are the variable names specified by SPECLIST.
   NSTEPS        number of time steps (optional; otherwise program processes all steps in all input files)
 ```
 
-## Input file types and format:
-
-Bldoverlay accepts "OBS" and "SITES" formats (FILETYPE) for the input file. For hourly output data (OLAYTYPE HOURLY) the program assumes that observations are in local standard time (LST) and applies a simple timezone shift to GMT using timezones every 15 degrees longitude.  For daily output data (OLAYTYPE DAILY, 1HRMAX or 8HRMAX) no time shifting is done so the output data remains in LST.  In this case the user can use the HR2DAY utility to time shift and average hourly model data to create daily model fields in LST.
-
-```
- OBS format:     The OBS format consists of comma separated values in the format 
-                 YYYDDD, HH, Site_ID, Longitude, Latitude, Value1[, Value2, Value3,...]. 
-                 Note that if the input data is daily that an hour column (HH) is still required 
-                 in the input data file.  In this case HH is ignored so the user could set this 
-                 value to 0 for all records.
- SITES format:   Set to create a static site file using the value set by VALUE (default is 1). 
-                 The format is a tab delimited file with the structure Site_ID Longitude Latitude.
-```
 
 ## Compile block_extract source code
 


### PR DESCRIPTION
block_extract README had a section on 'Input file types and format' that is for the bldoverlay utility, and not relevant to block_extract.