### PR TITLE
Update CMAQ_UG_appendixA_model_options.md

### DIFF
--- a/DOCS/Users_Guide/Appendix/CMAQ_UG_appendixA_model_options.md
+++ b/DOCS/Users_Guide/Appendix/CMAQ_UG_appendixA_model_options.md
@@ -435,12 +435,6 @@ Sets if the CCTM will run in multi-processor or serial mode.
 
 -   `CTM_OCEAN_CHEM [default: True]`<a id=CTM_SS_AERO></a>   
     Use Online Sea Spray Aerosol emissions and Halogen ozone chemistry. See [Chapter 6](../CMAQ_UG_ch06_model_configuration_options.md#sea-spray) for further information.  
--   `CTM_WB_DUST [default: False]`<a id=CTM_WB_DUST></a>  
-    Setting to calculate online windblown dust emissions in CCTM. Setting this variable to Y also enables the option to provide additional gridded landuse input files beyond the land use information contained in the MCIP files. Whether or not additional landuse information is provide and, if yes, whether that additional landuse information is provided in one or two files is controlled by the environment variable CTM_WBDUST_BELD. See [Chapter 6](../CMAQ_UG_ch06_model_configuration_options.md#wind-blown-dust) for further information.
-- `CTM_WBDUST_BELD [default: UNKNOWN]`<a id=CTM_WBDUST_BELD></a>  
-     Landuse database for identifying dust source regions; ignore if CTM_WB_DUST = FALSE
-    - BELD3: Use BELD3 landuse data for windblown dust calculations. The user needs to specify the DUST_LU_1 and DUST_LU_2 files described in [Chapter 4](../CMAQ_UG_ch04_model_inputs.md). These files typically are available for North American domains only.
-    - UNKNOWN: Use landuse information provided by MCIP for windblown dust calculations
 -   `CTM_LTNG_NO [default: Y]`<a id=CTM_LING_NO></a>  
     Y/N setting to activate lightning NO emissions. Setting this variable to Y requires additional variables to define the configuration of the lightning NO emissions calculation. See the settings for `LTNGNO`, `LTNGPARAMS`, `NLDN_STRIKES`, and `LTNGDIAG` below. See [Chapter 6](../CMAQ_UG_ch06_model_configuration_options.md#lightning-no) for further information.
 -   `KZMIN [default: Y]`<a id=KZMIN></a>  
@@ -672,11 +666,19 @@ Sets if the CCTM will run in multi-processor or serial mode.
 
 <!-- END COMMENT -->
 
+-   `CTM_WB_DUST [default: False]`<a id=CTM_WB_DUST></a>  
+    Setting to calculate online windblown dust emissions in CCTM. Setting this variable to Y also enables the option to provide additional gridded landuse input files beyond the land use information contained in the MCIP files. Whether or not additional landuse information is provide and, if yes, whether that additional landuse information is provided in one or two files is controlled by the environment variable CTM_WBDUST_BELD. See [Chapter 6](../CMAQ_UG_ch06_model_configuration_options.md#wind-blown-dust) for further information.
+    
+- `CTM_WBDUST_BELD [default: UNKNOWN]`<a id=CTM_WBDUST_BELD></a>  
+     Landuse database for identifying dust source regions; ignore if CTM_WB_DUST = FALSE
+    - BELD3: Use BELD3 landuse data for windblown dust calculations. The user needs to specify the DUST_LU_1 and DUST_LU_2 files described in [Chapter 4](../CMAQ_UG_ch04_model_inputs.md). These files typically are available for North American domains only.
+    - UNKNOWN: Use landuse information provided by MCIP for windblown dust calculations
+    
 -   `DUST_LU_1 [default: Path to BELD3 Data]`<a id=DUST_LU_1></a>  
-    Input BELD "A" landuse netCDF file gridded to the modeling domain. Used if `CTM_WBDUST_BELD` is set to BELD3.  
+    Input BELD "A" landuse netCDF file gridded to the modeling domain. Only used if `CTM_WBDUST_BELD` is set to BELD3.  
 
 -   `DUST_LU_2 [default: Path to BELD3 Data]`<a id=DUST_LU_2></a>  
-    Input BELD "TOT" landuse netCDF file gridded to the modeling domain. Used if `CTM_WBDUST_BELD` is set to BELD3.  
+    Input BELD "TOT" landuse netCDF file gridded to the modeling domain. Only used if `CTM_WBDUST_BELD` is set to BELD3.  
 
 
 


### PR DESCRIPTION
Moved text about CTM_WB_DUST and CTM_WBDUST_BELD to section in Appendix called 'Windblown dust emissions configuration'.  Previously the dust environment variables were described in two separate places in the Appendix.